### PR TITLE
use resetprop -n instead of setprop

### DIFF
--- a/common/post-fs-data.sh
+++ b/common/post-fs-data.sh
@@ -7,26 +7,26 @@ MODDIR=${0%/*}
 # More info in the main Magisk thread
 
 # Set CF DNS servers address
-setprop net.eth0.dns1 1.1.1.1
-setprop net.eth0.dns2 1.0.0.1
+resetprop -n net.eth0.dns1 1.1.1.1
+resetprop -n net.eth0.dns2 1.0.0.1
 
-setprop net.dns1 1.1.1.1
-setprop net.dns2 1.0.0.1
+resetprop -n net.dns1 1.1.1.1
+resetprop -n net.dns2 1.0.0.1
 
-setprop net.ppp0.dns1 1.1.1.1
-setprop net.ppp0.dns2 1.0.0.1
+resetprop -n net.ppp0.dns1 1.1.1.1
+resetprop -n net.ppp0.dns2 1.0.0.1
 
-setprop net.rmnet0.dns1 1.1.1.1
-setprop net.rmnet0.dns2 1.0.0.1
+resetprop -n net.rmnet0.dns1 1.1.1.1
+resetprop -n net.rmnet0.dns2 1.0.0.1
 
-setprop net.rmnet1.dns1 1.1.1.1
-setprop net.rmnet1.dns2 1.0.0.1
+resetprop -n net.rmnet1.dns1 1.1.1.1
+resetprop -n net.rmnet1.dns2 1.0.0.1
 
-setprop net.pdpbr1.dns1 1.1.1.1
-setprop net.pdpbr1.dns2 1.0.0.1
+resetprop -n net.pdpbr1.dns1 1.1.1.1
+resetprop -n net.pdpbr1.dns2 1.0.0.1
 
-setprop 2606:4700:4700::1111
-setprop 2606:4700:4700::1001
+resetprop -n 2606:4700:4700::1111
+resetprop -n 2606:4700:4700::1001
 
 
 


### PR DESCRIPTION
Use setprop in post-fs-data will cause deadlock, we should use resetprop -n instead.
Follow this document: https://topjohnwu.github.io/Magisk/guides.html#boot-scripts